### PR TITLE
Initialize static game center layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Game Center
+
+A sleek, mobile-first hub for web games with a dark, glassy look and neon accents. Currently static with placeholder game cards.
+The layout adapts to screen size, showing a bottom navigation bar on phones and a sidebar on desktops.
+
+## Development
+
+- `npm test` – run a simple check for the main layout
+- `npm start` – serve the site locally via `http-server`
+
+Open `index.html` directly or visit the local server to view the site. Future game pages can be linked by updating the `.game-card` anchors.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Game Center</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="app-header">
+    <h1>Game Center</h1>
+  </header>
+  <section class="hero">
+    <div class="hero-card">
+      <h2>Welcome to Game Center</h2>
+      <p>Play, connect, and discover.</p>
+    </div>
+  </section>
+  <section class="games-section">
+    <h2 class="section-title">Your Games</h2>
+    <div class="games-grid">
+      <a class="game-card" href="#">
+        <div class="game-thumb">🎮</div>
+        <h2>Game 1</h2>
+      </a>
+      <a class="game-card" href="#">
+        <div class="game-thumb">🔥</div>
+        <h2>Game 2</h2>
+      </a>
+      <a class="game-card" href="#">
+        <div class="game-thumb">🚀</div>
+        <h2>Game 3</h2>
+      </a>
+    </div>
+  </section>
+  <nav class="bottom-nav">
+    <a href="#"><span class="icon">🏠</span><span class="label">Home</span></a>
+    <a href="#"><span class="icon">🕹️</span><span class="label">Arcade</span></a>
+    <a href="#"><span class="icon">🤝</span><span class="label">Play</span></a>
+    <a href="#"><span class="icon">📚</span><span class="label">Library</span></a>
+  </nav>
+  <script>
+    function setDeviceClass() {
+      const desktop = window.matchMedia('(min-width: 768px)').matches;
+      document.body.classList.toggle('desktop', desktop);
+    }
+    window.addEventListener('resize', setDeviceClass);
+    setDeviceClass();
+  </script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "game-center",
+  "version": "0.1.0",
+  "description": "Sleek game hub with dark, glassy design.",
+  "scripts": {
+    "test": "node test.js",
+    "start": "npx http-server -c-1"
+  },
+  "license": "MIT"
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,157 @@
+:root {
+  --bg: #0d0d0f;
+  --card-bg: rgba(255, 255, 255, 0.05);
+  --accent: #00e0ff;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: var(--bg);
+  color: #fff;
+  font-family: system-ui, sans-serif;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header {
+  text-align: center;
+  padding: 1rem;
+  background: rgba(255, 255, 255, 0.05);
+  backdrop-filter: blur(10px);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
+}
+
+.games-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 1rem;
+  flex: 1;
+}
+
+.game-card {
+  position: relative;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  background: var(--card-bg);
+  border-radius: 1rem;
+  padding: 1rem;
+  min-height: 160px;
+  text-decoration: none;
+  color: inherit;
+  overflow: hidden;
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  transition: transform 0.2s, border-color 0.2s;
+}
+
+.game-card:hover {
+  transform: translateY(-4px);
+  border-color: var(--accent);
+  box-shadow: 0 0 15px var(--accent);
+}
+
+.game-card h2 {
+  z-index: 1;
+  font-size: 1rem;
+}
+
+.game-thumb {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2.5rem;
+  color: var(--accent);
+  opacity: 0.1;
+}
+
+.hero {
+  padding: 1rem;
+}
+
+.hero-card {
+  background: linear-gradient(135deg, var(--accent), #ff0099);
+  border-radius: 1.5rem;
+  padding: 2rem;
+  text-align: center;
+  margin: 0 0 1rem;
+  color: #fff;
+}
+
+.hero-card h2 {
+  font-size: 1.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.games-section {
+  padding: 0 1rem 4rem;
+}
+
+.section-title {
+  margin-bottom: 0.5rem;
+  font-size: 1.1rem;
+}
+
+.bottom-nav {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: rgba(255, 255, 255, 0.05);
+  backdrop-filter: blur(10px);
+  display: flex;
+  justify-content: space-around;
+  padding: 0.5rem 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.bottom-nav a {
+  color: #fff;
+  text-decoration: none;
+  font-size: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.bottom-nav .icon {
+  font-size: 1.2rem;
+}
+
+body.desktop .bottom-nav {
+  top: 0;
+  bottom: 0;
+  width: 80px;
+  flex-direction: column;
+  justify-content: flex-start;
+  padding-top: 1rem;
+  border-top: none;
+  border-right: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+body.desktop .bottom-nav a {
+  padding: 1rem 0;
+}
+
+body.desktop .app-header,
+body.desktop .hero,
+body.desktop .games-section {
+  margin-left: 80px;
+}
+
+body.desktop .games-section {
+  padding-bottom: 1rem;
+}
+
+body.desktop .games-grid {
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+}

--- a/test.js
+++ b/test.js
@@ -1,0 +1,16 @@
+const fs = require('fs');
+
+const html = fs.readFileSync('index.html', 'utf8');
+
+if (!html.includes('<h1>Game Center</h1>')) {
+  console.error('Missing header');
+  process.exit(1);
+}
+
+const cardCount = (html.match(/class="game-card"/g) || []).length;
+if (cardCount !== 3) {
+  console.error(`Expected 3 game cards, found ${cardCount}`);
+  process.exit(1);
+}
+
+console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- add mobile hero banner and navigation that turns into a sidebar on desktops
- detect screen size to toggle desktop class for specialized layout
- document responsive navigation in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1432e46c4832892cab4989188b53e